### PR TITLE
Task-57294: wrong Labels displayed

### DIFF
--- a/layout-management-webapps/src/main/resources/locale/portlet/layoutManagement/QuickEditLayoutPortlet_en.xml
+++ b/layout-management-webapps/src/main/resources/locale/portlet/layoutManagement/QuickEditLayoutPortlet_en.xml
@@ -20,7 +20,7 @@
       </action>
       <ManageSites>Manage Sites</ManageSites>
       <ManageGroupSites>Manage Group Sites</ManageGroupSites>
-      <TopbarTooltip>Edit pages and navigations</TopbarTooltip>
+      <TopbarTooltip>Edit layout</TopbarTooltip>
    </UIAdminToolbarPortlet>
 
   <UISEOForm>

--- a/layout-management-webapps/src/main/webapp/groovy/navigation/webui/component/UIAdminToolbarDrawerContainer.gtmpl
+++ b/layout-management-webapps/src/main/webapp/groovy/navigation/webui/component/UIAdminToolbarDrawerContainer.gtmpl
@@ -16,7 +16,7 @@
   String siteLabel = _ctx.appRes("UIAdminToolbarPortlet.action.Site");
   String addSiteLabel = _ctx.appRes("UIAdminToolbarPortlet.action.AddSite");
   String editAdministration = _ctx.appRes("UIAdminToolbarPortlet.TopbarTooltip");
-  String editTooltip = _ctx.appRes("UIAdminToolbarPortlet.topbarIcon.tooltip");
+  String editTooltip = _ctx.appRes("UIAdminToolbarPortlet.TopbarTooltip");
 
 
   PortalRequestContext context = Util.getPortalRequestContext();


### PR DESCRIPTION
Problem: hovering the chat and edit layout , the labels aren't the right ones
Fix: I tried to modified the tooltip, labels to make them display correctly when hovering on them