### PR TITLE
Task-57442: People not in group Administration or content management have the edit 

### DIFF
--- a/layout-management-webapps/src/main/webapp/WEB-INF/conf/layout-management/dynamic-container-configuration.xml
+++ b/layout-management-webapps/src/main/webapp/WEB-INF/conf/layout-management/dynamic-container-configuration.xml
@@ -26,7 +26,10 @@
             <field name="permissions">
               <collection type="java.util.ArrayList">
                 <value>
-                <string>*:/platform/users</string>
+                  <string>manager:/platform/administrators</string>
+                </value>
+                <value>
+                  <string>editor:/platform/web-contributors</string>
                 </value>
               </collection>
             </field>


### PR DESCRIPTION
Prior this change, all admin of space have the quick edit button.
This is a regression caused by the move of QuickEditLayoutPortlet in the middle toolbar container.
Fix:  Add removed permission to portlet QuickEditLayoutPortlet