### PR TITLE
fix: Icons with wrong color - MEED-1480

### DIFF
--- a/layout-management-webapps/src/main/webapp/groovy/navigation/webui/component/UIAdminToolbarDrawerContainer.gtmpl
+++ b/layout-management-webapps/src/main/webapp/groovy/navigation/webui/component/UIAdminToolbarDrawerContainer.gtmpl
@@ -138,7 +138,7 @@
   require(['SHARED/vuetify', 'SHARED/jquery', 'SHARED/vue'], function(vuetify, jq){
     new Vue({
       el: '#DrawerEditAdministration',
-      vuetify: new Vuetify(),
+      vuetify: Vue.prototype.vuetifyOptions,
       data () {
         return {
           editDrawer: null,


### PR DESCRIPTION
Prior to this change, the icons on the overview page were displayed in the wrong secondary color, this was because Vuetify was overriding the color due to a non-recommended declaration