### PR TITLE
feat: Update navigation REST service to retrieve only current site navigation nodes - EXO-63564 - Meeds-io/meeds#51

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawer.vue
@@ -56,10 +56,9 @@ export default {
       this.$refs.siteNavigationDrawer.close();
     },
     getNavigationNodes() {
-      return this.$navigationService.getNavigations(this.siteName, this.siteType)
+      return this.$siteNavigationService.getNavigationNodes(this.siteType, this.siteName, false)
         .then(navigationNodes => {
-          this.navigationNodes = navigationNodes?.filter(navigationNode => navigationNode.siteKey.name.toLowerCase() === this.siteName.toLowerCase()
-              && navigationNode.siteKey.type.toLowerCase() === this.siteType.toLowerCase()) || [];
+          this.navigationNodes = navigationNodes || [];
         });
     },
   }

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/initComponents.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/initComponents.js
@@ -32,3 +32,11 @@ const components = {
 for (const key in components) {
   Vue.component(key, components[key]);
 }
+
+import * as siteNavigationService from './siteNavigationService';
+
+if (!Vue.prototype.$siteNavigationService) {
+  window.Object.defineProperty(Vue.prototype, '$siteNavigationService', {
+    value: siteNavigationService,
+  });
+}

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/siteNavigationService.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/siteNavigationService.js
@@ -1,0 +1,20 @@
+
+export function getNavigationNodes(siteType, siteName, includeGlobal) {
+  const formData = new FormData();
+  if (siteName) {
+    formData.append('siteName', siteName);
+  }
+  formData.append('includeGlobal', includeGlobal);
+
+  const params = new URLSearchParams(formData).toString();
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/navigations/${siteType || 'portal'}?${params}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error(resp.status);
+    } else {
+      return resp.json();
+    }
+  });
+}


### PR DESCRIPTION

Prior to this change, since the navigation rest service returns by default not only the navigation nodes of the needed portal site but also those of the default site "Global", a frontend filtering of these unneeded nodes has been done. After this change, we will update the navigation rest service call with includeGlobal=false in order to retrieve only exact navigation nodes of the current portal site.