### PR TITLE
feat: Display 3 dots icon of site navigation drawer on hover of the navigation nodes - EXO-63615

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
@@ -15,46 +15,47 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-<v-hover>
+  <v-hover>
     <div slot-scope="{ hover }">
-    <v-list-item
-      dense
-      class="px-0">
-      <v-list-item-action class="me-2 my-0">
-        <v-icon
-          v-if="hasChildren"
-          size="24"
-          @click="displayChildren = !displayChildren">
-          {{ icon }}
-        </v-icon>
-        <div v-else class="mfs-3 mfe-2"></div>
-      </v-list-item-action>
-      <v-list-item-content>
-        <v-list-item-title
-          :title="navigationNode.label"
-          class="font-weight-bold text-truncate">
-          {{ navigationNode.label }}
-        </v-list-item-title>
-        <v-list-item-subtitle
-          :title="navigationNodeUri"
-          class="text-truncate">
-          {{ navigationNodeUri }}
-        </v-list-item-subtitle>
-      </v-list-item-content>
-      <v-list-item-action class="mx-0 my-0">
-        <site-navigation-node-item-menu :navigation-node="navigationNode"
-        :hover="hover" />
-      </v-list-item-action>
-    </v-list-item>
-    <div v-if="displayChildren">
-      <site-navigation-node-item
-        v-for="child in navigationNode.children"
-        :key="child.id"
-        :navigation-node="child"
-        class="ms-7" />
+      <v-list-item
+        dense
+        class="px-0">
+        <v-list-item-action class="me-2 my-0">
+          <v-icon
+            v-if="hasChildren"
+            size="24"
+            @click="displayChildren = !displayChildren">
+            {{ icon }}
+          </v-icon>
+          <div v-else class="mfs-3 mfe-2"></div>
+        </v-list-item-action>
+        <v-list-item-content>
+          <v-list-item-title
+            :title="navigationNode.label"
+            class="font-weight-bold text-truncate">
+            {{ navigationNode.label }}
+          </v-list-item-title>
+          <v-list-item-subtitle
+            :title="navigationNodeUri"
+            class="text-truncate">
+            {{ navigationNodeUri }}
+          </v-list-item-subtitle>
+        </v-list-item-content>
+        <v-list-item-action class="mx-0 my-0">
+          <site-navigation-node-item-menu
+            :navigation-node="navigationNode"
+            :hover="hover" />
+        </v-list-item-action>
+      </v-list-item>
+      <div v-if="displayChildren">
+        <site-navigation-node-item
+          v-for="child in navigationNode.children"
+          :key="child.id"
+          :navigation-node="child"
+          class="ms-7" />
+      </div>
     </div>
-  </div>
-</v-hover>
+  </v-hover>
 </template>
 
 <script>

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
@@ -15,7 +15,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div>
+<v-hover>
+    <div slot-scope="{ hover }">
     <v-list-item
       dense
       class="px-0">
@@ -41,7 +42,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         </v-list-item-subtitle>
       </v-list-item-content>
       <v-list-item-action class="mx-0 my-0">
-        <site-navigation-node-item-menu :navigation-node="navigationNode" />
+        <site-navigation-node-item-menu :navigation-node="navigationNode"
+        :hover="hover" />
       </v-list-item-action>
     </v-list-item>
     <div v-if="displayChildren">
@@ -52,6 +54,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         class="ms-7" />
     </div>
   </div>
+</v-hover>
 </template>
 
 <script>

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItemMenu.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItemMenu.vue
@@ -24,6 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     class="px-0 mx-2 overflow-visible">
     <template #activator="{ on, attrs }">
       <v-btn
+        v-show="hover"
         v-bind="attrs"
         class="pull-right"
         icon
@@ -66,6 +67,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <script>
 export default {
   props: {
+    hover: {
+      type: Boolean,
+      default: () => false,
+    },
     navigationNode: {
       type: Object,
       default: null,


### PR DESCRIPTION
Prior to this change,  the 3 dots icon is always appearing into the site navigation drawer. After this change, the 3 dots icon will appear only when we hover on the navigation nodes.