### PR TITLE
feat: Display Edit layout action only for users having page edit permission - EXO-63629 - Meeds-io/meeds#51

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItemMenu.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItemMenu.vue
@@ -34,7 +34,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </template>
     <v-list class="pa-0" dense>
       <v-list-item
-        v-if="navigationNode.pageKey"
+        v-if="canEditPage"
         class="subtitle-2" 
         @click="editLayout">
         <v-icon


### PR DESCRIPTION
this change is to make only those who have the edit right on the page access to edit layout action