### PR TITLE
feat: Fix display of the 3 dots icon on parent nodes when hovering on child nodes - EXO-63843 - Meeds-io/MIPs#51 

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/NodeItem.vue
@@ -15,51 +15,53 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <v-hover>
-    <div slot-scope="{ hover }">
-      <v-list-item
-        dense
-        class="px-0">
-        <v-list-item-action class="me-2 my-0">
-          <v-icon
-            v-if="hasChildren"
-            size="24"
-            @click="displayChildren = !displayChildren">
-            {{ icon }}
-          </v-icon>
-          <div v-else class="mfs-3 mfe-2"></div>
-        </v-list-item-action>
-        <v-list-item-content>
-          <v-list-item-title
-            :title="navigationNode.label"
-            class="font-weight-bold text-truncate">
-            {{ navigationNode.label }}
-          </v-list-item-title>
-          <v-list-item-subtitle
-            :title="navigationNodeUri"
-            class="text-truncate">
-            {{ navigationNodeUri }}
-          </v-list-item-subtitle>
-        </v-list-item-content>
-        <v-list-item-action class="mx-0 my-0">
-          <site-navigation-node-item-menu
-            :navigation-node="navigationNode"
-            :hover="hover"
-            :can-move-up="canMoveUp"
-            :can-move-down="canMoveDown" />
-        </v-list-item-action>
-      </v-list-item>
-      <div v-if="displayChildren">
-        <site-navigation-node-item
-          v-for="child in navigationNode.children"
-          :key="child.id"
-          :navigation-node="child"
-          :can-move-up="canMoveUpChildNode(child)"
-          :can-move-down="canMoveDownChildNode(child)"
-          class="ms-7" />
+  <div>
+    <v-hover>
+      <div slot-scope="{ hover }">
+        <v-list-item
+          dense
+          class="px-0">
+          <v-list-item-action class="me-2 my-0">
+            <v-icon
+              v-if="hasChildren"
+              size="24"
+              @click="displayChildren = !displayChildren">
+              {{ icon }}
+            </v-icon>
+            <div v-else class="mfs-3 mfe-2"></div>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title
+              :title="navigationNode.label"
+              class="font-weight-bold text-truncate">
+              {{ navigationNode.label }}
+            </v-list-item-title>
+            <v-list-item-subtitle
+              :title="navigationNodeUri"
+              class="text-truncate">
+              {{ navigationNodeUri }}
+            </v-list-item-subtitle>
+          </v-list-item-content>
+          <v-list-item-action class="mx-0 my-0">
+            <site-navigation-node-item-menu
+              :navigation-node="navigationNode"
+              :hover="hover"
+              :can-move-up="canMoveUp"
+              :can-move-down="canMoveDown" />
+          </v-list-item-action>
+        </v-list-item>
       </div>
+    </v-hover>
+    <div v-if="displayChildren">
+      <site-navigation-node-item
+        v-for="child in navigationNode.children"
+        :key="child.id"
+        :navigation-node="child"
+        :can-move-up="canMoveUpChildNode(child)"
+        :can-move-down="canMoveDownChildNode(child)"
+        class="ms-7" />
     </div>
-  </v-hover>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Prior to this change, when hovering on a child node, the three dots are displayed on both child node and parent node. After this fix, we ensure that the three dots are displayed only on the hovered node itself.