### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.exoplatform.addons</groupId>
-		<artifactId>addons-parent-pom</artifactId>
-		<version>17-exo-M01</version>
+		<artifactId>addons-parent-exo-pom</artifactId>
+		<version>17-security-fix-SNAPSHOT</version>
 	</parent>
 	<groupId>org.exoplatform.addons.layout-management</groupId>
 	<artifactId>layout-management</artifactId>
@@ -31,7 +31,7 @@
 	</modules>
 	<properties>
 		<!-- 3rd party libraries versions -->
-		<org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
+		<org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
 		
 		<!-- Sonar properties -->
 		<sonar.organization>exoplatform</sonar.organization>
@@ -40,9 +40,9 @@
 		<dependencies>
 			<!-- Import versions from projects -->
 			<dependency>
-				<groupId>org.exoplatform.social</groupId>
-				<artifactId>social</artifactId>
-				<version>${org.exoplatform.social.version}</version>
+				<groupId>org.exoplatform.commons-exo</groupId>
+				<artifactId>commons-exo</artifactId>
+				<version>${org.exoplatform.commons-exo.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.exoplatform.addons</groupId>
-		<artifactId>addons-parent-exo-pom</artifactId>
+		<artifactId>addons-exo-parent-pom</artifactId>
 		<version>17-security-fix-SNAPSHOT</version>
 	</parent>
 	<groupId>org.exoplatform.addons.layout-management</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.exoplatform.addons</groupId>
 		<artifactId>addons-exo-parent-pom</artifactId>
-		<version>17-security-fix-SNAPSHOT</version>
+		<version>17-M01</version>
 	</parent>
 	<groupId>org.exoplatform.addons.layout-management</groupId>
 	<artifactId>layout-management</artifactId>
@@ -31,7 +31,7 @@
 	</modules>
 	<properties>
 		<!-- 3rd party libraries versions -->
-		<org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
+		<org.exoplatform.commons-exo.version>6.5.x-SNAPSHOT</org.exoplatform.commons-exo.version>
 		
 		<!-- Sonar properties -->
 		<sonar.organization>exoplatform</sonar.organization>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds
