### PR TITLE
fix: Fix insert left/right action of column container - EXO-64611 - Meeds-io/MIPs#51

### DIFF
--- a/layout-management-webapps/src/main/webapp/groovy/portal/webui/container/UIColumnContainer.gtmpl
+++ b/layout-management-webapps/src/main/webapp/groovy/portal/webui/container/UIColumnContainer.gtmpl
@@ -1,0 +1,124 @@
+<%
+  import org.exoplatform.commons.utils.ExpressionUtil;
+  import org.exoplatform.portal.webui.workspace.UIPortalApplication;
+  import org.exoplatform.webui.core.UIComponent;
+  import org.exoplatform.commons.utils.HTMLEntityEncoder;
+  
+  def rcontext = _ctx.getRequestContext();
+  ResourceBundle res = rcontext.getApplicationResourceBundle();
+  def requirejs = rcontext.getJavascriptManager().getRequireJS();
+  requirejs.require("SHARED/bts_dropdown","bts_dropdown");
+
+  UIPortalApplication uiPortalApp = rcontext.getUIApplication();
+  boolean hasPermission = uicomponent.hasPermission();
+  if(!uiPortalApp.isEditing() && !hasPermission) return;
+
+  String cssStyle = "";
+  String uiComponentWidth = uicomponent.getWidth();
+  String uiComponentHeight = uicomponent.getHeight();
+  if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
+  if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+  if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
+  if(cssStyle.length() > 0) cssStyle += "\"";
+
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
+  /** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
+  String componentId = uicomponent.getId();
+  if(componentId.startsWith("UIContainer-")){
+    uicomponent.setId(componentId.substring("UIContainer-".length()));
+  }
+
+  if (uiPortalApp.isEditing())
+  {
+     def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
+     reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
+%>  
+<div class="UIContainer SimpleColumnContainer EdittingContainer <%=uiComponentClass%>"
+        id="${uicomponent.id}" ${cssStyle}>
+<%
+  }
+  else
+  {   
+%>
+<div class="UIContainer SimpleColumnContainer <%=uiComponentClass%>  <%=hasPermission?"": "ProtectedContainer"%>"
+        id="${uicomponent.id}" ${cssStyle}>
+<%
+  }
+%>  <div class="NormalContainerBlock UIComponentBlock">
+
+      <%
+        int portalMode = uiPortalApp.getModeState();
+        if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == UIPortalApplication.APP_BLOCK_EDIT_MODE){
+      %>
+        <div class="LAYOUT-CONTAINER LAYOUT-BLOCK">
+      <%} else {%>
+        <div class="VIEW-CONTAINER VIEW-BLOCK">
+      <%} %> 
+          <div class="UIIntermediateContainer">
+          <%if(hasPermission) {%>
+              <div id="${uicomponent.id}Children" class="UIRowContainer <%=(portalMode != UIPortalApplication.NORMAL_MODE && uicomponent.getChildren().size() == 0) ? "EmptyContainer" : ""%>">
+                <%
+                
+                  uicomponent.renderChildren();                 
+        
+                %>
+              </div>
+            <% } else { %>
+              <div id="${uicomponent.id}Children" class="ProtectedContent">
+                <%=_ctx.appRes("UIPortlet.label.protectedContent")%>
+              </div>
+            <% } %>
+          </div>
+        </div>
+        
+        
+      <%if(portalMode != UIPortalApplication.NORMAL_MODE){%>
+        <div class="EDITION-BLOCK EDITION-CONTAINER" style="position: relative; display: none;">
+
+            <div style="position: absolute; top: -86px;">
+
+              <div class="NewLayer" style="display: none; visibility: hidden;"><span></span></div>
+              <div class="CONTROL-CONTAINER CONTROL-BLOCK uiInfoBar">
+                <%/*Begin InfoBar*/%>
+                    <i class="uiIconDragDrop uiIconWhite" rel='tooltip' data-placement='right' title="<%=_ctx.appRes("UIColumnContainer.title.DragControlArea")%>"></i>
+                    <% 
+                      String strTitle = uicomponent.getTitle() != null ?
+                            ExpressionUtil.getExpressionValue(res, uicomponent.getTitle()) :
+                            _ctx.appRes("UISimpleColumnContainer.title.Container");
+                      strTitle = hasPermission ? strTitle : _ctx.appRes("UIPortlet.label.protectedContent");
+                    %>
+                    <i class="uiIconContainerConfig uiIconWhite"></i>
+                    <span><%=HTMLEntityEncoder.getInstance().encode(strTitle)%></span>
+                    <%if(hasPermission) {%>
+                      <div class="dropdown" style="display: inline-block">
+                        <a data-toggle="dropdown" class="dropdown-toggle" rel='tooltip' data-placement='bottom' title="<%= _ctx.appRes("UIColumnContainer.tooltip.insertColumn") %>">
+                          <i class="uiIconArrowDown uiIconWhite"></i>
+                        </a>
+                        <% /*Begin Popup Menu*/ %>
+                        <ul class="dropdown-menu" role="menu">
+                          <li>                            
+                            <a class="OptionItem" href="javascript:void(0);" onclick="<%= uicomponent.event("InsertColumn", org.exoplatform.portal.webui.container.UIColumnContainer.INSERT_BEFORE) %>">
+                              <%= _ctx.appRes("UIColumnContainer.label.insertLeft") %>
+                            </a>
+                          </li>
+                          <li>                            
+                            <a class="OptionItem" href="javascript:void(0);" onclick="<%= uicomponent.event("InsertColumn", org.exoplatform.portal.webui.container.UIColumnContainer.INSERT_AFTER) %>">
+                              <%= _ctx.appRes("UIColumnContainer.label.insertRight") %>
+                            </a>
+                          </li>
+                        </ul>                                             
+                        <% /*End Popup Menu*/ %>
+                      </div>
+                      <a href="javascript:void(0);" onclick="<%=uicomponent.event("EditContainer")%>" rel="tooltip" data-placement="bottom" title="<%=_ctx.appRes("UIColumnContainer.tooltip.editContainer")%>"><i class="uiIconEdit uiIconWhite"></i></a>
+                      <a href="javascript:void(0);" onclick="<%=uicomponent.event("DeleteComponent")%>" rel="tooltip" data-placement="bottom" title="<%=_ctx.appRes("UIColumnContainer.tooltip.closeContainer")%>"><i class="uiIconTrash uiIconWhite"></i></a>
+                    <%}%>                   
+                  </div>
+                <%/*End InfoBar*/ %>
+              </div>
+              
+            </div> 
+      <%} %>
+      
+  </div> 
+</div>


### PR DESCRIPTION

Prior to this fix, the default template UIColumnContainer.gtmpl on gatein-portal is missing bts_dropdow js declaration which makes the insert left/right action not working. After this commit, we will override the default template by another which will declare the bts_dropdow js.