### PR TITLE
fix: Fix site navigation behavior issues from manage space portlet - EXO-65306 - Meeds-io/MIPs#68

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawer.vue
@@ -65,8 +65,8 @@ export default {
     return {
       navigationNodes: [],
       navigationNodesToDisplay: [],
-      siteName: eXo.env.portal.siteKeyName,
-      siteType: eXo.env.portal.siteKeyType,
+      siteName: null,
+      siteType: null,
       loading: false,
       filter: 'ALL',
     };
@@ -104,18 +104,20 @@ export default {
   },
   methods: {
     open(event) {
-      this.getNavigationNodes(event);
+      this.siteName = event?.siteName || eXo.env.portal.siteKeyName;
+      this.siteType = event?.siteType || eXo.env.portal.siteKeyType;
+      this.getNavigationNodes();
       this.$refs.siteNavigationDrawer.open();
       this.$nextTick().then(() =>  this.$root.$emit('site-navigation-drawer-opened'));
     },
     close() {
+      this.siteName = null;
+      this.siteType = null;
       this.$root.$emit('site-navigation-hide-nodes-tree');
       this.$refs.siteNavigationDrawer.close();
     },
-    getNavigationNodes(data) {
+    getNavigationNodes() {
       this.loading = true;
-      this.siteName = data?.siteName || eXo.env.portal.siteKeyName;
-      this.siteType = data?.siteType || eXo.env.portal.siteKeyType;
       return this.$siteNavigationService.getNavigationNodes(this.siteType, this.siteName, false, true)
         .then(navigationNodes => {
           this.navigationNodes = navigationNodes || [];


### PR DESCRIPTION
Prior to this change, after performing an action from the site navigation opened from space management portlet, the refresh is done without any site type and site name datas but with the default current ones.
After this change, the site name and site type will change whenever the site navigation drawer is opened so that every action will take the right data.