### PR TITLE
fix: Fix updating site - EXO-66773 - Meeds-io/MIPs#72

### DIFF
--- a/layout-management-services/src/main/java/org/exoplatform/layoutmanagement/rest/SiteManagementRestService.java
+++ b/layout-management-services/src/main/java/org/exoplatform/layoutmanagement/rest/SiteManagementRestService.java
@@ -142,10 +142,10 @@ public class SiteManagementRestService implements ResourceContainer {
       portalConfig.setLabel(siteLabel);
       portalConfig.setDisplayed(displayed);
       portalConfig.setDisplayOrder(displayed ? displayOrder : 0);
-      if (bannerRemoved) {
-       layoutService.removeSiteBanner(siteName);
-       portalConfig.setBannerFileId(0);
-      } else {
+      if (bannerRemoved && portalConfig.getBannerFileId() != 0) {
+        layoutService.removeSiteBanner(siteName);
+        portalConfig.setBannerFileId(0);
+      } else if (StringUtils.isNotBlank(bannerUploadId)) {
         portalConfig.setBannerUploadId(bannerUploadId);
       }
       layoutService.save(portalConfig);

--- a/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SiteCardPropertiesDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SiteCardPropertiesDrawer.vue
@@ -231,9 +231,10 @@ export default {
       this.displayed = site.displayed;
       this.displayOrder = site.displayOrder;
       this.siteBannerUrl = site.bannerUrl;
-      this.defaultSiteBannerUrl = this.siteBannerUrl.replace('isDefault=false', 'isDefault=true');
-      this.isDefaultBanner = this.siteBannerUrl?.includes('&isDefault=true') ;
+      this.defaultSiteBannerUrl = `/portal/rest/v1/social/sites/${site.name}/banner?isDefault=true`;
+      this.isDefaultBanner = site.bannerFileId === 0 ;
       this.hasDefaultBanner = this.isDefaultBanner;
+      this.bannerUploadId = null;
       this.$nextTick().then(() => {
         this.$refs.siteCardPropertiesDrawer.open();
       });


### PR DESCRIPTION
Prior to this change, when you open the drawer to update a new created site, the bannerUploadId is set to "0" and the API request param bannerRemoved is set to true resulting an exception for sites that have not set a new banner.
After this change, the bannerUploadId is set to null on each drawer opening.