### PR TITLE
fix: fix displaying undo delete success message - EXO-67597

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/NodeItemMenu.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/NodeItemMenu.vue
@@ -245,13 +245,14 @@ export default {
       const deleteDelay = 6;
       const message = this.$t('siteNavigation.label.deleteSuccess');
       const undoMessage = this.$t('siteNavigation.label.undoDelete');
+      const undoMessageSuccess = this.$t('siteNavigation.deleteCanceled');
       this.$siteNavigationService.deleteNode(this.navigationNode.id, deleteDelay)
         .then(() => {
           document.dispatchEvent(new CustomEvent('alert-message', {detail: {
             alertType: 'success',
             alertMessage: message ,
             alertLinkText: undoMessage ,
-            alertLinkCallback: () => this.undoDeleteNode(this.navigationNode.id),
+            alertLinkCallback: () => this.undoDeleteNode(this.navigationNode.id, undoMessageSuccess),
           }}));
         });
       const redirectionTime = 6100;
@@ -322,12 +323,12 @@ export default {
         });
 
     },
-    undoDeleteNode(nodeId) {
+    undoDeleteNode(nodeId, successMsg) {
       return this.$siteNavigationService.undoDeleteNode(nodeId)
         .then(() => {
           this.$root.$emit('refresh-navigation-nodes');
           this.$root.$emit('close-alert-message');
-          this.$root.$emit('alert-message', this.$t('siteNavigation.deleteCanceled'), 'success');
+          this.$root.$emit('alert-message', successMsg, 'success');
         });
     }
   }


### PR DESCRIPTION
Before this change, after undo deleting a node , no success message is displayed and error is displayed in console :  Cannot read properties of null (reading '_t')  since the message is defined into the callback function
after this change, the success message is defined out of the callback function and the success message is displayed