### PR TITLE
fix: Add site navigation extension in a load-group - EXO-68206

### DIFF
--- a/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -141,7 +141,7 @@
   </module>
 
   <module>
-    <name>NavigationManageSpaceActions</name>
+    <name>ManageSpacesExtension</name>
     <load-group>ManageSpaceGRP</load-group>
      <script>
         <path>/js/siteNavigation.bundle.js</path>

--- a/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -140,6 +140,39 @@
     </depends>
   </module>
 
+  <module>
+    <name>NavigationManageSpaceActions</name>
+    <load-group>ManageSpaceGRP</load-group>
+     <script>
+        <path>/js/siteNavigation.bundle.js</path>
+     </script>
+     <depends>
+      <module>extensionRegistry</module>
+     </depends>
+     <depends>
+      <module>eXoVueI18n</module>
+     </depends>
+     <depends>
+      <module>vue</module>
+     </depends>
+     <depends>
+      <module>vuetify</module>
+     </depends>
+     <depends>
+      <module>commonVueComponents</module>
+     </depends>
+      <depends>
+        <module>commonLayoutComponents</module>
+      </depends>
+     <depends>
+      <module>translationField</module>
+     </depends>
+      <depends>
+      <module>jquery</module>
+      <as>$</as>
+    </depends>
+  </module>
+
   <portlet>
     <name>SiteNavigation</name>
     <module>

--- a/layout-management-webapps/src/main/webapp/skin/less/common/Style.less
+++ b/layout-management-webapps/src/main/webapp/skin/less/common/Style.less
@@ -8,6 +8,9 @@
   .scheduleEndDatePicker {
     max-width: ~"calc(100% - 125px)";
   }
+  .v-input input {
+    box-shadow: none !important;
+  }
 }
 
 #nodeIconPickerDrawer {

--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManageAccessPermission.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManageAccessPermission.vue
@@ -16,7 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div>
-    <span class="font-weight-bold text-start text-color body-2">{{ whoCanView }}</span>
+    <p class="font-weight-bold text-start text-color body-2">{{ whoCanView }}</p>
     <v-select
       v-model="type"
       :items="typeLabel"

--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManageEditPermission.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManageEditPermission.vue
@@ -16,7 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div>
-    <span class="font-weight-bold text-start text-color body-2">{{ whoCanEdit }}</span>
+    <p class="font-weight-bold text-start text-color body-2">{{ whoCanEdit }}</p>
     <exo-identity-suggester
       ref="navigationNodeEditPermissions"
       :labels="suggesterLabels"

--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationElementDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationElementDrawer.vue
@@ -38,7 +38,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <v-form
           v-model="isValidForm">
           <template>
-            <span class="font-weight-bold text-start text-color body-2">{{ $t('siteNavigation.label.selectElementType') }}</span>
+            <span class="font-weight-bold text-start text-truncate-2 text-color body-2">{{ $t('siteNavigation.label.selectElementType') }}</span>
             <v-select
               v-model="elementType"
               :items="elementTypes"
@@ -49,7 +49,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               outlined />
           </template>
           <template>
-            <span class="font-weight-bold text-start text-color body-2 mt-8">{{ $t('siteNavigation.label.selectOpenType') }}</span>
+            <span class="font-weight-bold text-start text-truncate-2 text-color body-2 mt-8">{{ $t('siteNavigation.label.selectOpenType') }}</span>
             <v-select
               v-model="target"
               :items="targetTypes"

--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationExistingPageElement.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationExistingPageElement.vue
@@ -16,8 +16,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div>
-    <span class="font-weight-bold text-start text-color body-2 mt-8">{{ $t('siteNavigation.label.selectExistingPage') }}</span>
-    <v-flex class="mt-4">
+    <span class="font-weight-bold text-start text-truncate-2 text-color body-2 mt-8">{{ $t('siteNavigation.label.selectExistingPage') }}</span>
+    <v-flex class="mt-4 text-left">
       <v-chip
         :class="allSitesChipClass"
         @click="allSites = true">

--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationNodeDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationNodeDrawer.vue
@@ -39,7 +39,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           v-model="isValidInputs">
           <v-card-text class="d-flex pb-2">
             <v-label>
-              <span class="text-color font-weight-bold">
+              <span class="text-color font-weight-bold text-start text-truncate-2">
                 {{ $t('siteNavigation.label.nodeLabel.title') }} *              
               </span>
               <p class="caption">{{ $t('siteNavigation.label.nodeLabel.description') }} </p>
@@ -67,12 +67,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </v-card-text>
           <v-card-text class="d-flex flex-grow-1 pb-2">
             <v-label>
-              <span class="text-color font-weight-bold mr-6">
+              <span class="text-color font-weight-bold text-start mr-6 text-truncate-2">
                 {{ $t('siteNavigation.label.nodeId.title') }} *              
               </span>
               <p
                 v-if="nodeId && nodeId.length"
-                class="caption text-break">
+                class="caption text-break mx-auto text-wrap text-left">
                 {{ nodeUrl }}
               </p>
             </v-label>
@@ -90,7 +90,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </v-card-text>
           <v-card-text class="d-flex flex-grow-1 pb-2">
             <v-label>
-              <span class="text-color font-weight-bold mr-6">
+              <span class="text-color font-weight-bold text-start mr-6 text-truncate-2">
                 {{ $t('siteNavigation.label.icon.title') }}             
               </span>
               <p class="caption"> {{ $t('siteNavigation.label.icon.description') }}  </p>
@@ -209,7 +209,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     {{ $t('siteNavigation.label.editElement') }}
                   </a>
                 </div>
-                <p class="caption text-light-color ms-8 me-2">
+                <p class="caption text-light-color ms-8 me-2 text-wrap text-break text-truncate-2">
                   {{ $t('siteNavigation.label.nodeType.pageOrLink.caption') }}
                 </p>
               </v-radio-group>

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigation.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigation.vue
@@ -16,7 +16,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <v-app v-if="canManageSiteNavigation && !isMobile">
-    <site-navigation-button icon-class="text-color" />
+    <site-navigation-button
+      icon-class="text-color" 
+      :icon-color="iconColor"
+      :disabled="disabled"
+      :site-name="siteName"
+      :site-type="siteType" />
     <site-navigation-drawer v-if="siteNavigationDrawerOpened" />
     <manage-permissions-drawer v-if="siteNavigationDrawerOpened" />
     <site-navigation-node-drawer v-if="siteNavigationDrawerOpened" />
@@ -29,6 +34,22 @@ export default {
     canManageSiteNavigation: {
       type: Boolean,
       default: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    iconColor: {
+      type: String,
+      default: null,
+    },
+    siteName: {
+      type: String,
+      default: null,
+    },
+    siteType: {
+      type: String,
+      default: null,
     },
   },
   data () {

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
@@ -44,6 +44,8 @@ const lang = eXo && eXo.env.portal.language || 'en';
 //should expose the locale ressources as REST API
 const urls = [`${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.layoutManagement.SiteNavigationPortlet-${lang}.json`];
 
+exoi18n.loadLanguageAsync(lang, urls);
+
 export function init(canManageSiteNavigation) {
   exoi18n.loadLanguageAsync(lang, urls).then(i18n => {
     // init Vue app when locale ressources are ready

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
@@ -29,7 +29,7 @@ if (extensionRegistry) {
 
 extensionRegistry.registerComponent('manageSpaceActions', 'manage-space-actions', {
   id: 'manage-space-actions',
-  vueComponent: Vue.options.components['site-navigation-button'],
+  vueComponent: Vue.options.components['site-navigation'],
   rank: 20,
 });
 


### PR DESCRIPTION
Prior to this change, the site navigation icon is not displayed on the space administration page due to the hide of sharedLayout for the aggregated site containing the site navigation portlet.This commit creates a load-group for site navigation, which will then be loaded with the Spaces Administration Portlet.