### PR TITLE
fix: Allow to update the node permissions to everyone twice - EXO-68151

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManagePermissionsDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/manage-permissions/ManagePermissionsDrawer.vue
@@ -171,7 +171,7 @@ export default {
       this.$refs.managePermissionsDrawer.startLoading();
       const pageEditPermission = this.convertPermission(this.editPermission);
       let pageAccessPermissions = ['Everyone'];
-      if (this.accessPermissions[0] !== 'Everyone') {
+      if (this.accessPermissions[0] !== 'Everyone' && this.accessPermissionType !== 'Everyone') {
         pageAccessPermissions = [];
         this.accessPermissions.forEach(permission => {
           if (permission.group?.id) {


### PR DESCRIPTION
Prior to this change, we were not allowed to update the node permissions to everyone twice. This was due to an incorrect build of the node accessPermissions list. This change updates the condition to correctly build the accessPermissions list.