### PR TITLE
fix: Add site navigation extension in a load-group - EXO-68206

### DIFF
--- a/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/layout-management-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -144,7 +144,7 @@
     <name>ManageSpacesExtension</name>
     <load-group>ManageSpaceGRP</load-group>
      <script>
-        <path>/js/siteNavigation.bundle.js</path>
+      <path>/js/siteNavigation.bundle.js</path>
      </script>
      <depends>
       <module>extensionRegistry</module>

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationButton.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationButton.vue
@@ -62,6 +62,10 @@ export default {
       type: String,
       default: null,
     },
+    siteId: {
+      type: String,
+      default: null,
+    },
   },
   methods: {
     openSiteNavigationDrawer() {
@@ -70,6 +74,7 @@ export default {
         params = {
           siteName: this.siteName,
           siteType: this.siteType,
+          siteId: this.siteId,
         };
       }
       document.dispatchEvent(new CustomEvent('open-site-navigation-drawer',{detail: params}));

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawersActions.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/components/SiteNavigationDrawersActions.vue
@@ -15,24 +15,28 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <v-app v-if="canManageSiteNavigation && !isMobile">
-    <site-navigation-button
-      icon-class="text-color" />
-    <site-navigation-drawers-actions />
-  </v-app>
+  <div v-if="siteNavigationDrawerOpened">
+    <site-navigation-drawer />
+    <manage-permissions-drawer />
+    <site-navigation-node-drawer />
+    <site-navigation-element-drawer />
+  </div>
 </template>
 <script>
 export default {
-  props: {
-    canManageSiteNavigation: {
-      type: Boolean,
-      default: false,
-    }
+  data () {
+    return {
+      siteNavigationDrawerOpened: false,
+    };
   },
-  computed: {
-    isMobile() {
-      return this.$vuetify.breakpoint.width < 768 ;
-    },
+  created() {
+    document.addEventListener('open-site-navigation-drawer', event => this.openSiteNavigationDrawer(event.detail));
+  },
+  methods: {
+    openSiteNavigationDrawer(data) {
+      this.siteNavigationDrawerOpened = true;
+      this.$nextTick().then(() => this.$root.$emit('open-site-navigation-drawer', data));
+    }
   }
 };
 </script>

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/initComponents.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/initComponents.js
@@ -16,10 +16,12 @@
  */
 import SiteNavigation from './components/SiteNavigation.vue';
 import SiteNavigationButton from './components/SiteNavigationButton.vue';
+import SiteNavigationDrawersActions from './components/SiteNavigationDrawersActions.vue';
 
 const components = {
   'site-navigation': SiteNavigation,
   'site-navigation-button': SiteNavigationButton,
+  'site-navigation-drawers-actions': SiteNavigationDrawersActions
 };
 
 for (const key in components) {

--- a/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-navigation/main.js
@@ -29,7 +29,13 @@ if (extensionRegistry) {
 
 extensionRegistry.registerComponent('manageSpaceActions', 'manage-space-actions', {
   id: 'manage-space-actions',
-  vueComponent: Vue.options.components['site-navigation'],
+  vueComponent: Vue.options.components['site-navigation-button'],
+  rank: 20,
+});
+
+extensionRegistry.registerComponent('manageSpaceDrawers', 'manage-space-drawers', {
+  id: 'manage-space-drawers',
+  vueComponent: Vue.options.components['site-navigation-drawers-actions'],
   rank: 20,
 });
 


### PR DESCRIPTION
Prior to this change, the site navigation icon is not displayed on the space administration page due to the hide of sharedLayout for the aggregated site containing the site navigation portlet.This commit creates a load-group for site navigation, which will then be loaded with the Spaces Administration Portlet.