### PR TITLE
fix: Allow special character in url validation during the link node creation - EXO-67762 

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationElementDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationElementDrawer.vue
@@ -106,7 +106,7 @@ export default {
       elementType: 'PAGE',
       target: 'SAME_TAB',
       link: '',
-      linkRules: [url => !!(url?.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9]+\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
+      linkRules: [url => !!(url?.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9:._\\/+=-]+\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
               || ( !url?.length && this.$t('siteNavigation.required.error.message') || this.$t('siteNavigation.label.invalidLink'))],
       navigationNode: null,
       elementName: null,


### PR DESCRIPTION
Prior to this change, special characters were not allowed during the creation of link nodes. This modification enables the inclusion of special characters in URL validation during the creation of link nodes