### PR TITLE
fix: Disable save button when editing site properties with 0 or negative display order - EXO-69031

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SitePropertiesDrawer.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SitePropertiesDrawer.vue
@@ -156,6 +156,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           v-if="editMode"
           :loading="loading"
           @click="updateSite"
+          :disabled="saveDisabled"
           class="btn btn-primary ms-2">
           {{ $t('siteManagement.label.btn.save') }}
         </v-btn>


### PR DESCRIPTION
before this change, while editing the site and changing the display order to a negative value the save btn is not disabled since there is no check about rules in edit mode
After this change, rules are added for edit mode and checks are made while editing a site