### PR TITLE
fix: fix displayeing site name in site cards - EXO-68195 (#322)

### DIFF
--- a/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SiteCard.vue
+++ b/layout-management-webapps/src/main/webapp/vue-app/site-management/components/SiteCard.vue
@@ -26,7 +26,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       flat
       dense
       class="mt-2">
-      <span class="font-weight-bold text-capitalize">  {{ site.displayName || site.name }} </span>
+      <span class="font-weight-bold">  {{ site.displayName || site.name }} </span>
       <v-spacer />
       <site-management-site-card-menu
         :site="site" />


### PR DESCRIPTION
before this change, the site name was capitalized on the site card: The name is displayed in upper case for each word no matter what has been written in the menu. After this change, the site name is displayed without capitalizing every word