### PR TITLE
fix: fix container display to respect width css rules - EXO-68837 - Meeds-io/meeds#1769

### DIFF
--- a/layout-management-webapps/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
+++ b/layout-management-webapps/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
@@ -17,7 +17,12 @@
   String uiComponentWidth = uicomponent.getWidth();
   String uiComponentHeight = uicomponent.getHeight();
   if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-  if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+  if(uiComponentWidth != null) {
+    cssStyle += "width: "+uiComponentWidth+";"
+    if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+      cssStyle += "min-width: "+uiComponentWidth+";"
+    }
+  }
   if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
   if(cssStyle.length() > 0) cssStyle += "\"";
 


### PR DESCRIPTION
before this change, when adding a container that one of its sub-containers having a width with "calc" the sub-containers do not respect the width CSS rules when containing a portlet with a huge width
After this change, when setting the with as the min-width for the container it respects the CSS rules and its width do not change